### PR TITLE
MINOR: Surface the TLS error if a connection couldn't be made, so that further diagnosis is possible

### DIFF
--- a/symantec.rb
+++ b/symantec.rb
@@ -184,7 +184,7 @@ class SymantecChecker
       return [host, :good]
     end
   rescue StandardError => ex
-    return [host, :error]
+    return [host, ex.message]
   end
 end
 


### PR DESCRIPTION
This is just a minor QOL improvement - I had ~2,000 hosts to run through, and plenty of them gave errors. I sorted through them and found that a lot failed because the SSL handshake didn't complete in two seconds, so I re-ran those and found some issues - figured this would be helpful for others to review as well.

That being said, it does clutter the JSON quite a bit - I also write a PHP script to sort through all the results and separate them into individual lists to make it easier to read which will come in a separate PR.