### PR TITLE
Fix CSV.open not correctly populating the hostname

### DIFF
--- a/symantec.rb
+++ b/symantec.rb
@@ -189,10 +189,10 @@ class SymantecChecker
 end
 
 def main(file)
-  hosts = CSV.open(file) do |csv|
-    csv.map do |index, host|
-      host
-    end
+  hosts = Array.new
+
+  CSV.foreach(file) do |host|
+    hosts.push(host[0])
   end
   puts "Read #{hosts.length} hosts"
 


### PR DESCRIPTION
For some reason on my local machine (Mac OSX, Ruby 2.4.1), the original code creates an empty array of hosts (the `hosts` array has the correct length, but all entries of the array are blank). Looking at the stdlib docs for CSV, it appears that the preferred way to read files is via `CSV.foreach`.

I'm happy to be proven wrong, I'm not quite sure what I'm doing wrong here. The test file I was using just had each hostname on a separate line in the file, which seems to be what this script was looking for?